### PR TITLE
Prevent items from entering drawers without room for the item

### DIFF
--- a/lua/api.lua
+++ b/lua/api.lua
@@ -144,6 +144,10 @@ function drawers.drawer_on_dig(pos, node, player)
 end
 
 function drawers.drawer_allow_metadata_inventory_put(pos, listname, index, stack, player)
+	if core.is_protected(pos,player:get_player_name()) then
+	   core.record_protection_violation(pos,player:get_player_name())
+	   return 0
+	end
 	if listname ~= "upgrades" then
 		return 0
 	end
@@ -198,6 +202,7 @@ function drawers.register_drawer(name, def)
 	def.on_destruct = drawers.drawer_on_destruct
 	def.on_dig = drawers.drawer_on_dig
 	def.allow_metadata_inventory_put = drawers.drawer_allow_metadata_inventory_put
+	def.allow_metadata_inventory_take = drawers.drawer_allow_metadata_inventory_put
 	def.on_metadata_inventory_put = drawers.add_drawer_upgrade
 	def.on_metadata_inventory_take = drawers.remove_drawer_upgrade
 

--- a/lua/api.lua
+++ b/lua/api.lua
@@ -194,7 +194,6 @@ function drawers.drawer_can_insert_object(pos, node, stack, direction)
 		leftover = visual:try_insert_stack(leftover, true)
 	end
 	return not (leftover == stack)
-
 end
 
 function drawers.register_drawer(name, def)

--- a/lua/api.lua
+++ b/lua/api.lua
@@ -185,6 +185,18 @@ function drawers.drawer_insert_object(pos, node, stack, direction)
 	return leftover
 end
 
+function drawers.drawer_can_insert_object(pos, node, stack, direction)
+   	local drawer_visuals = drawers.drawer_visuals[core.serialize(pos)]
+	if not drawer_visuals then return false end
+
+	local leftover = stack
+	for _, visual in pairs(drawer_visuals) do
+		leftover = visual:try_insert_stack(leftover, true)
+	end
+	return not (leftover == stack)
+
+end
+
 function drawers.register_drawer(name, def)
 	def.description = def.description or S("Wooden")
 	def.drawtype = "nodebox"
@@ -215,7 +227,10 @@ function drawers.register_drawer(name, def)
 		def.groups.tubedevice_receiver = 1
 		def.tube = def.tube or {}
 		def.tube.insert_object = def.tube.insert_object or
-			drawers.drawer_insert_object
+		   drawers.drawer_insert_object
+		def.tube.can_insert = def.tube.can_insert or
+		   drawers.drawer_can_insert_object
+
 		def.tube.connect_sides = {left = 1, right = 1, back = 1, top = 1,
 			bottom = 1}
 		def.after_place_node = pipeworks.after_place

--- a/lua/visual.lua
+++ b/lua/visual.lua
@@ -147,6 +147,10 @@ core.register_entity("drawers:visual", {
 	end,
 
 	on_rightclick = function(self, clicker)
+	        if core.is_protected(self.drawer_pos, clicker:get_player_name()) then
+		   core.record_protection_violation(self.drawer_pos, clicker:get_player_name())
+		   return
+		end
 		local leftover = self.try_insert_stack(self, clicker:get_wielded_item(),
 			not clicker:get_player_control().sneak)
 
@@ -160,7 +164,10 @@ core.register_entity("drawers:visual", {
 
 	on_punch = function(self, puncher, time_from_last_punch, tool_capabilities, dir)
 		local add_stack = not puncher:get_player_control().sneak
-
+		if core.is_protected(self.drawer_pos, puncher:get_player_name()) then
+		   core.record_protection_violation(self.drawer_pos, puncher:get_player_name())
+		   return
+		end
 		local inv = puncher:get_inventory()
 		local spaceChecker = ItemStack(self.itemName)
 		if add_stack then


### PR DESCRIPTION
This makes pipeworks more efficient, since large drawer networks can now be handled.