### PR TITLE
Items with max stack of 1 have name saved in metadata

### DIFF
--- a/lua/visual.lua
+++ b/lua/visual.lua
@@ -245,6 +245,7 @@ core.register_entity("drawers:visual", {
 
 		-- Don't add items stackable only to 1
 		if self.itemStackMax == 1 then
+			self.itemName = ""
 			return itemstack
 		end
 


### PR DESCRIPTION
Fix issue where storage drawer saves item name for items with max stack of 1 causing you to not be able to put in other items until breaking the drawer or reloading the game. To replicate the issue, right click on a drawer with something like a written book that has a max stack of one and then try right clicking on the drawer with an item that would normally work. It won't go in because the book name was saved in the metadata.

If you want to fix this a different way, that's fine. I figured this was the easiest thing to do. Also I've never done pull request before so I hope I'm doing it right.