### PR TITLE
Increase entity check radius by 0.03 and add automatic drawer check

### DIFF
--- a/lua/helpers.lua
+++ b/lua/helpers.lua
@@ -197,7 +197,7 @@ function drawers.spawn_visuals(pos)
 end
 
 function drawers.remove_visuals(pos)
-	local objs = core.get_objects_inside_radius(pos, 0.537)
+	local objs = core.get_objects_inside_radius(pos, 0.54)
 	if not objs then return end
 
 	for _, obj in pairs(objs) do

--- a/lua/visual.lua
+++ b/lua/visual.lua
@@ -77,6 +77,12 @@ core.register_entity("drawers:visual", {
 			self.drawerType = drawers.last_drawer_type
 		end
 
+		local node = minetest.get_node(self.object:get_pos())
+		if not node.name:match("^drawers:") then
+			self.object:remove()
+			return
+		end
+
 		-- add self to public drawer visuals
 		-- this is needed because there is no other way to get this class
 		-- only the underlying LuaEntitySAO
@@ -385,7 +391,7 @@ core.register_lbm({
 		-- count the drawer visuals
 		local drawerType = core.registered_nodes[node.name].groups.drawer
 		local foundVisuals = 0
-		local objs = core.get_objects_inside_radius(pos, 0.537)
+		local objs = core.get_objects_inside_radius(pos, 0.54)
 		if objs then
 			for _, obj in pairs(objs) do
 				if obj and obj:get_luaentity() and


### PR DESCRIPTION
I found the drawers on my server were piling up entities without getting rid of them. Using WorldEdit I found that the radius of 0.537 was too small to see the extras, and increasing it by 0.01 fixed it. I increased it by 0.03 in the PR just to make it a nice number and account for any stray entities it might find. 