### PR TITLE
Nil inv and controller gui fixes

### DIFF
--- a/lua/controller.lua
+++ b/lua/controller.lua
@@ -78,17 +78,16 @@ end
 local function controller_formspec(pos, meta_current_state)
 	local formspec = 
 		"size[8,8.5]"..
-		default.gui_bg..
-		default.gui_bg_img..
-		default.gui_slots..
+		drawers.gui_bg..
+		drawers.gui_bg_img..
+		drawers.gui_slots..
 		"label[0,0;" .. S("Current State: ") .. meta_current_state .. "]" ..
 		"list[current_name;src;3.5,1.75;1,1;]"..
 		"list[current_player;main;0,4.25;8,1;]"..
 		"list[current_player;main;0,5.5;8,3;8]"..
 		"listring[current_player;main]"..
 		"listring[current_name;src]"..
-		"listring[current_player;main]"..
-		default.get_hotbar_bg(0, 4.25)
+		"listring[current_player;main]"
 	return formspec
 end
 

--- a/lua/visual.lua
+++ b/lua/visual.lua
@@ -180,6 +180,9 @@ core.register_entity("drawers:visual", {
 		   return
 		end
 		local inv = puncher:get_inventory()
+		if inv == nil then
+			return	
+		end
 		local spaceChecker = ItemStack(self.itemName)
 		if add_stack then
 			spaceChecker:set_count(spaceChecker:get_stack_max())


### PR DESCRIPTION
I made two bug fixes. The first adds a check to make sure the inv of the drawer puncher isn't nil. I didn't realize other things in the world could even punch the drawers, but I guess so. I unfortunately couldn't test this fix. The person reporting the problem used a mod with an archer that is outdated and broken. I couldn't get the archers to do anything. In theory though it should fix it.

The second fix is adding the gui changes that were made to the drawers in the past to the drawer controller. It was using default textures and causing issues for MCL2. I see you fixed that and used the same fix for the controller. I tested it and confirmed it works in both default and MCL2.