### PR TITLE
Increase core.get_objects_inside_radius to stop drawer visuals get recreated on every block load

### DIFF
--- a/lua/helpers.lua
+++ b/lua/helpers.lua
@@ -197,7 +197,7 @@ function drawers.spawn_visuals(pos)
 end
 
 function drawers.remove_visuals(pos)
-	local objs = core.get_objects_inside_radius(pos, 0.54)
+	local objs = core.get_objects_inside_radius(pos, 0.56)
 	if not objs then return end
 
 	for _, obj in pairs(objs) do

--- a/lua/visual.lua
+++ b/lua/visual.lua
@@ -434,7 +434,7 @@ core.register_lbm({
 		-- count the drawer visuals
 		local drawerType = core.registered_nodes[node.name].groups.drawer
 		local foundVisuals = 0
-		local objs = core.get_objects_inside_radius(pos, 0.54)
+		local objs = core.get_objects_inside_radius(pos, 0.56)
 		if objs then
 			for _, obj in pairs(objs) do
 				if obj and obj:get_luaentity() and


### PR DESCRIPTION
Fix for #43

(cherry picked from commit 740a78c73144229f61ece818864c01f741ce4cd0)