### PR TITLE
appears to fix wrong stacking

### DIFF
--- a/lua/visual.lua
+++ b/lua/visual.lua
@@ -317,6 +317,7 @@ core.register_entity("drawers:visual", {
 			self.count = 0
 			self.itemName = itemstack:get_name()
 			self.maxCount = itemstack:get_stack_max() * self.stackMaxFactor
+			self.itemStackMax = itemstack:get_stack_max()
 		end
 
 		-- update everything


### PR DESCRIPTION
Apparently the metadata was not updated with the size of a stack for an inserted item, so the percentages were wrong and the number of dropped items on change wrong for items where the maximum stack number is not 99.

In my own testing after this, it appears to not drop an obscene amount of stacks and the percentage full looks right.

Related: https://github.com/minetest-mods/drawers/issues/52