### PR TITLE
Fix #57 by using core.hash_node_position for reliable indexing

### DIFF
--- a/lua/api.lua
+++ b/lua/api.lua
@@ -89,8 +89,8 @@ function drawers.drawer_on_destruct(pos)
 	drawers.remove_visuals(pos)
 
 	-- clean up visual cache
-	if drawers.drawer_visuals[core.serialize(pos)] then
-		drawers.drawer_visuals[core.serialize(pos)] = nil
+	if drawers.drawer_visuals[core.hash_node_position(pos)] then
+		drawers.drawer_visuals[core.hash_node_position(pos)] = nil
 	end
 end
 
@@ -193,7 +193,7 @@ end
 	Inserts an incoming stack into a drawer and uses all slots.
 ]]
 function drawers.drawer_insert_object_from_tube(pos, node, stack, direction)
-	local drawer_visuals = drawers.drawer_visuals[core.serialize(pos)]
+	local drawer_visuals = drawers.drawer_visuals[core.hash_node_position(pos)]
 	if not drawer_visuals then
         return stack
     end
@@ -231,7 +231,7 @@ end
 	Returns whether a stack can be (partially) inserted to any slot of a drawer.
 ]]
 function drawers.drawer_can_insert_stack_from_tube(pos, node, stack, direction)
-	local drawer_visuals = drawers.drawer_visuals[core.serialize(pos)]
+	local drawer_visuals = drawers.drawer_visuals[core.hash_node_position(pos)]
 	if not drawer_visuals then
 		return false
 	end
@@ -245,7 +245,7 @@ function drawers.drawer_can_insert_stack_from_tube(pos, node, stack, direction)
 end
 
 function drawers.drawer_take_item(pos, itemstack)
-	local drawer_visuals = drawers.drawer_visuals[core.serialize(pos)]
+	local drawer_visuals = drawers.drawer_visuals[core.hash_node_position(pos)]
 
 	if not drawer_visuals then
 		return ItemStack("")

--- a/lua/controller.lua
+++ b/lua/controller.lua
@@ -274,7 +274,7 @@ local function controller_insert_to_drawers(pos, stack)
 		-- will put the items in the drawer
 		if content.name == stack:get_name() and
 				content.count < content.maxCount and
-				drawers.drawer_visuals[core.serialize(drawer_pos)] then
+				drawers.drawer_visuals[core.hash_node_position(drawer_pos)] then
 			return drawers.drawer_insert_object(drawer_pos, stack, visualid)
 		end
 	elseif drawer_net_index["empty"] then
@@ -284,7 +284,7 @@ local function controller_insert_to_drawers(pos, stack)
 
 		-- If the drawer is still empty and the drawer entity is loaded, we will
 		-- put the items in the drawer
-		if content.name == "" and drawers.drawer_visuals[core.serialize(drawer_pos)] then
+		if content.name == "" and drawers.drawer_visuals[core.hash_node_position(drawer_pos)] then
 			local leftover = drawers.drawer_insert_object(drawer_pos, stack, visualid)
 
 			-- Add the item to the drawers table index and set the empty one to nil

--- a/lua/helpers.lua
+++ b/lua/helpers.lua
@@ -215,7 +215,7 @@ end
 	visualid can be: "", "1", "2", ... or 1, 2, ...
 ]]
 function drawers.get_visual(pos, visualid)
-	local drawer_visuals = drawers.drawer_visuals[core.serialize(pos)]
+	local drawer_visuals = drawers.drawer_visuals[core.hash_node_position(pos)]
 	if not drawer_visuals then
 		return nil
 	end
@@ -256,7 +256,7 @@ function drawers.update_drawer_upgrades(pos)
 	stackMaxFactor = stackMaxFactor / drawerType
 
 	-- set the new stack max factor in all visuals
-	local drawer_visuals = drawers.drawer_visuals[core.serialize(pos)]
+	local drawer_visuals = drawers.drawer_visuals[core.hash_node_position(pos)]
 	if not drawer_visuals then return end
 
 	for _,visual in pairs(drawer_visuals) do

--- a/lua/visual.lua
+++ b/lua/visual.lua
@@ -89,7 +89,7 @@ core.register_entity("drawers:visual", {
 		-- PLEASE contact me, if this is wrong
 		local vId = self.visualId
 		if vId == "" then vId = 1 end
-		local posstr = core.serialize(self.drawer_pos)
+		local posstr = core.hash_node_position(self.drawer_pos)
 		if not drawers.drawer_visuals[posstr] then
 			drawers.drawer_visuals[posstr] = {[vId] = self}
 		else


### PR DESCRIPTION
The previously used minetest.serialize function may provide different
results for the same table in certain circumstances, thus it is not
suitable for generating strings to index tables with.