### PR TITLE
Fix crash when removing upgrades from drawer surrounded by non-air nodes

### DIFF
--- a/lua/visual.lua
+++ b/lua/visual.lua
@@ -374,7 +374,7 @@ core.register_entity("drawers:visual", {
 		local dropPos = core.find_node_near(self.drawer_pos, 1, {"air"}, false)
 		-- if no pos found then drop on the top of the drawer
 		if not dropPos then
-			dropPos = self.pos
+			dropPos = self.object:get_pos()
 			dropPos.y = dropPos.y + 1
 		end
 		-- drop the item stack


### PR DESCRIPTION
Fixes #59 