### PR TITLE
Fix controller `can_insert` function returning number instead of boolean

### DIFF
--- a/lua/controller.lua
+++ b/lua/controller.lua
@@ -479,7 +479,7 @@ local function register_controller()
 		end
 
 		def.tube.can_insert = function(pos, node, stack, tubedir)
-			return controller_allow_metadata_inventory_put(pos, "src", nil, stack, nil)
+			return controller_allow_metadata_inventory_put(pos, "src", nil, stack, nil) > 0
 		end
 
 		def.tube.connect_sides = {


### PR DESCRIPTION
Fixes a bug where items from tubes would always enter the drawer controller even when it can't accept them, causing items to get stuck in tubes.

An example setup: Items should go into the drawer controller if there is room, otherwise they go into the trash. Before this fix they would instead go back to the tube they came from, because the trash has a lower priority.

![image](https://user-images.githubusercontent.com/48543043/151304690-e6afb8ba-fa2d-4871-995f-58bb288d9c7d.png)