### PR TITLE
Update controller inventory to be compatible with mcl2

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -31,12 +31,13 @@ local NS = minetest.get_translator('drawers')
 
 drawers = {}
 drawers.drawer_visuals = {}
+drawers.mcl_loaded = core.get_modpath("mcl_core") and mcl_core
 
 drawers.WOOD_ITEMSTRING = "group:wood"
 if core.get_modpath("default") and default then
 	drawers.WOOD_SOUNDS = default.node_sound_wood_defaults()
 	drawers.CHEST_ITEMSTRING = "default:chest"
-elseif core.get_modpath("mcl_core") and mcl_core then -- MineClone 2
+elseif drawers.mcl_loaded then -- MineClone 2
 	drawers.CHEST_ITEMSTRING = "mcl_chests:chest"
 	if core.get_modpath("mcl_sounds") and mcl_sounds then
 		drawers.WOOD_SOUNDS = mcl_sounds.node_sound_wood_defaults()
@@ -58,9 +59,16 @@ drawers.CONTROLLER_RANGE = 14
 
 drawers.gui_bg = "bgcolor[#080808BB;true]"
 drawers.gui_slots = "listcolors[#00000069;#5A5A5A;#141318;#30434C;#FFF]"
-drawers.inventory_list = "list[current_player;main;0.5,2.5;8,4;]"
-if (core.get_modpath("mcl_core")) and mcl_core then -- MCL2
-	drawers.inventory_list = "list[current_player;main;0,2.5;9,4;]"
+function drawers.inventory_list(posy)
+	local hotbar_row_posy = posy + 1.25
+	local inventory_list= "list[current_player;main;0.5,"..posy..";8,1;]" ..
+						  "list[current_player;main;0.5,"..hotbar_row_posy..";8,3;8]"
+	if drawers.mcl_loaded then -- MCL2
+		hotbar_row_posy = posy + 3.25
+		inventory_list = "list[current_player;main;0,"..posy..";9,3;9]" ..
+						 "list[current_player;main;0,"..hotbar_row_posy..";9,1;]"
+	end
+	return inventory_list
 end
 
 --
@@ -143,7 +151,7 @@ if core.get_modpath("default") and default then
 		drawer_stack_max_factor = 32, -- 4 * 8 normal chest size
 		material = "default:pine_wood"
 	})
-elseif core.get_modpath("mcl_core") and mcl_core then
+elseif drawers.mcl_loaded then
 	drawers.register_drawer("drawers:oakwood", {
 		description = S("Oak Wood"),
 		tiles1 = drawers.node_tiles_front_other("drawers_oak_wood_front_1.png",
@@ -288,7 +296,7 @@ if core.get_modpath("default") and default then
 		groups = {drawer_upgrade = 700},
 		recipe_item = "default:diamond"
 	})
-elseif core.get_modpath("mcl_core") and mcl_core then
+elseif drawers.mcl_loaded then
 	drawers.register_drawer_upgrade("drawers:upgrade_iron", {
 		description = S("Iron Drawer Upgrade (x2)"),
 		inventory_image = "drawers_upgrade_iron.png",
@@ -338,7 +346,7 @@ end
 -- Register drawer trim
 --
 
-if core.get_modpath("mcl_core") and mcl_core then
+if drawers.mcl_loaded then
 	core.register_node("drawers:trim", {
 		description = S("Wooden Trim"),
 		tiles = {"drawers_trim.png"},

--- a/lua/api.lua
+++ b/lua/api.lua
@@ -37,7 +37,7 @@ drawers.node_box_simple = {
 
 drawers.drawer_formspec = "size[9,6.7]" ..
 	"list[context;upgrades;2,0.5;5,1;]" ..
-	drawers.inventory_list ..
+	drawers.inventory_list(2.5) ..
 	"listring[context;upgrades]" ..
 	"listring[current_player;main]" ..
 	drawers.gui_bg ..

--- a/lua/controller.lua
+++ b/lua/controller.lua
@@ -42,20 +42,18 @@ continue scanning drawers. ]]--
 local S = minetest.get_translator('drawers')
 
 local default_loaded = core.get_modpath("default") and default
-local mcl_loaded = core.get_modpath("mcl_core") and mcl_core
 local pipeworks_loaded = core.get_modpath("pipeworks") and pipeworks
 local digilines_loaded = core.get_modpath("digilines") and digilines
 local techage_loaded = core.get_modpath("techage") and techage
 
 local function controller_formspec(pos)
 	local formspec =
-		"size[8,8.5]"..
+		"size[9,8.5]"..
 		drawers.gui_bg..
 		drawers.gui_slots..
 		"label[0,0;" .. S("Drawer Controller") .. "]" ..
-		"list[current_name;src;3.5,1.75;1,1;]"..
-		"list[current_player;main;0,4.25;8,1;]"..
-		"list[current_player;main;0,5.5;8,3;8]"..
+		"list[current_name;src;4,1.75;1,1;]"..
+		drawers.inventory_list(4.25) ..
 		"listring[current_player;main]"..
 		"listring[current_name;src]"..
 		"listring[current_player;main]"
@@ -445,7 +443,7 @@ local function register_controller()
 	end
 
 	-- MCL2 requires a few different groups and parameters that MTG does not
-	if mcl_loaded then
+	if drawers.mcl_loaded then
 		def.groups = {
 			pickaxey = 1, stone = 1, building_block = 1, material_stone = 1
 		}
@@ -520,7 +518,7 @@ if default_loaded then
 			{'default:steel_ingot', 'default:diamond', 'default:steel_ingot'},
 		}
 	})
-elseif mcl_loaded then
+elseif drawers.mcl_loaded then
 	core.register_craft({
 		output = 'drawers:controller',
 		recipe = {


### PR DESCRIPTION
Use the same inventory layout in controller.lua than in api.lua for drawer inventory.

The inventory in mcl2 is 9 slots per row and the hotbar is displayed at the bottom.
The default game inventory is 8 slots per row and the hotbar is displayed at the top.

For consistency and make the mcl2 inventory full visible, I made larger the controller formspec size.

## Screenshot of how it's now

### default game
![image](https://github.com/minetest-mods/drawers/assets/14837771/e463b8d6-c7ce-4c1a-8442-2a74eb3e4db9)
![image](https://github.com/minetest-mods/drawers/assets/14837771/11ba11de-fd8c-4fb3-9ff6-a75869003720)

### Mineclone2
![image](https://github.com/minetest-mods/drawers/assets/14837771/037a4157-a430-4883-a66b-295954d49683)
![image](https://github.com/minetest-mods/drawers/assets/14837771/78452b47-7d53-45c2-95b1-6ec990c32d46)
