### PR TITLE
[no squash] Add pipeworks tag support to controllers

### DIFF
--- a/docs/digiline.md
+++ b/docs/digiline.md
@@ -1,0 +1,10 @@
+# Drawer Controller Digilines Reference
+
+Drawer controllers can be controlled via Digiline. The Drawer Controller accepts Digiline mesages of the type `"string"` and `"table"` that are convertible to `ItemStack` as documented in [lua_api.md](https://github.com/luanti-org/luanti/blob/master/doc/lua_api.md?plain=1), section "Item formats". Any ItemStack information but name and count are ignored.
+
+Examples:
+
+* `"default:dirt 99"`
+* `{ name = "default:dirt", count = 99 }`
+
+The controller will then try its best to take that much of items and inject it into the tube behind it. If there are no enough items to fulfill the requirement, all the remaining items of the same name will be taken.

--- a/docs/digiline.md
+++ b/docs/digiline.md
@@ -8,3 +8,22 @@ Examples:
 * `{ name = "default:dirt", count = 99 }`
 
 The controller will then try its best to take that much of items and inject it into the tube behind it. If there are no enough items to fulfill the requirement, all the remaining items of the same name will be taken.
+
+## Adding tags to injected items
+
+To use this feature, [tag support](https://github.com/mt-mods/pipeworks/pull/107#issuecomment-1925943467) must be present and enabled on pipeworks. Make sure you're on the latest version of pipeworks.
+
+To assign tags to the injected items, you must use the table format when interacting with the drawer controller. Add one of the following fields to your table. If both `tags` and `tag` are specified, `tags` takes the precedence.
+
+* `tags = { <array of tags> } or "<comma-separated tags>"`
+* `tag = "<one single tag>"`
+
+For example, to assign the injected item both the `"factory"` and `"furnace"` tags:
+
+```lua
+digiline_send("drawer_controller", {
+    name = "default:sand",
+    count = 99,
+    tags = { "factory", "furnace" },
+})
+```

--- a/docs/digiline.md
+++ b/docs/digiline.md
@@ -8,3 +8,22 @@ Examples:
 * `{ name = "default:dirt", count = 99 }`
 
 The controller will then try its best to take that much of items and inject it into the tube behind it. If there are no enough items to fulfill the requirement, all the remaining items of the same name will be taken.
+
+## Adding tags to injected items
+
+To use this feature, [tag support](https://github.com/mt-mods/pipeworks/pull/107#issuecomment-1925943467) must be present and enabled on pipeworks. Make sure you're on the latest version of pipeworks.
+
+To assign tags to the injected items, you must use the table format when interacting with the drawer controller. Add one of the following fields to your table. If both `tags` and `tag` are specified, `tags` takes the precedence.
+
+* `tags = { <array of tags> } or "<comma-separated tags>"`
+* `tag = "<one single tag>"`
+
+For example, to assign the injected item both the `"factory"` and `"furnace"` tags:
+
+```lua
+digiline__send("drawer_controller", {
+    name = "default:sand",
+    count = 99,
+    tags = { "factory", "furnace" },
+})
+```

--- a/lua/controller.lua
+++ b/lua/controller.lua
@@ -396,7 +396,18 @@ local function controller_on_digiline_receive(pos, _, channel, msg)
 
 	-- prevent error if taken_stack ended up with a nil value
 	if taken_stack then
-		pipeworks.tube_inject_item(pos, pos, dir, taken_stack:to_string())
+		local tags = nil
+
+		-- Set item tags if provided in msg.tags or msg.tag
+		if pipeworks.enable_item_tags and type(msg) == "table" then
+			if type(msg.tags) == "table" or type(msg.tags) == "string" then
+				tags = pipeworks.sanitize_tags(msg.tags)
+			elseif type(msg.tag) == "string" then
+				tags = pipeworks.sanitize_tags({msg.tag})
+			end
+		end
+
+		pipeworks.tube_inject_item(pos, pos, dir, taken_stack, nil, tags)
 	end
 end
 


### PR DESCRIPTION
Supports passing msg.tags table into controllers via digiline to set tag on the injected item.

Example Luacontroller code for testing:

```lua
if event.type ~= "program" then return end

digiline_send("controller", {
    name = "drawers:aspen_wood1",
    count = 1,
    tags = { "a", "b" },
})
```

Combine the above with a tag sorting tube setup to test.

This PR is ready for review.