### PR TITLE
Fix error when rendering fallback image in table format

### DIFF
--- a/lua/helpers.lua
+++ b/lua/helpers.lua
@@ -52,7 +52,7 @@ end
 -- Get an image string from a tile definition
 local function tile_to_image(tile, fallback_image)
 	if not tile then
-		return fallback_image
+		return tile_to_image(fallback_image)
 	end
 	local tile_type = type(tile)
 	if tile_type == "string" then


### PR DESCRIPTION
Fixes error when rendering mesecons_extrawires:corner_off, which results in calling core.inventorycube with the following arguments without this change:

```lua
core.inventorycube {
    "jeija_insulated_wire_sides_off.png",
    setref(1){
        backface_culling = true,
        name = "jeija_insulated_wire_ends_off.png",
    },
    getref(1),
}
```