### PR TITLE
fix `drawers_fix` link rot right as it happened

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -6,7 +6,7 @@ License of source code:
 Copyright (C) 2017-2020 Linus Jahn <lnj@kaidan.im>
 Copyright (C) 2016 Mango Tango <mtango688@gmail.com>
 `/drawers_fix` command copyright (C) 2021 Pandorabox. MIT.
- - <https://github.com/pandorabox-io/pandorabox_custom/blob/master/chat/drawers_fix.lua>
+ - <https://github.com/pandorabox-io/pandorabox_custom/blob/9434e2cf7c64ea2a8d6070dda4b5eaf53812d750/chat/drawers_fix.lua>
  - Slight modifications (C) 2026 AbbyRead. MIT.
 
 MIT License


### PR DESCRIPTION
relevant commit https://github.com/pandorabox-io/pandorabox_custom/commit/7c71f236cbb1bb20417b5f1a1d07f46f157c38ee