### PR TITLE
Use `ItemStack:get_short_description()`

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,8 +21,7 @@ drawer upgrades to your drawer! They are available in different sizes and are
 crafted by steel, gold, obsidian, diamonds or mithril.
 
 ## Notes
-This mod requires Luanti 5.0 or later. The `default` mod from MTG or the
-MineClone 2 mods are only optional dependencies for crafting recipes.
+The `default` mod from MTG or the MineClone 2 mods are only optional dependencies for crafting recipes.
 
 ## To-Do
 - [x] Add usable 1x1 drawer

--- a/lua/visual.lua
+++ b/lua/visual.lua
@@ -470,11 +470,7 @@ core.register_entity("drawers:visual", {
 	end,
 
 	updateInfotext = function(self)
-		local item_def = core.registered_items[self.itemName]
-		local itemDescription = ""
-		if item_def then
-			itemDescription = item_def.short_description or item_def.description
-		end
+		local itemDescription = ItemStack(self.itemName):get_short_description()
 
 		if self.count <= 0 then
 			self.itemName = ""

--- a/mod.conf
+++ b/mod.conf
@@ -1,4 +1,4 @@
 name = drawers
 description = Storage Drawers - A Mod adding simple storages for items and blocks, showing the item's inventory image in the front.
 optional_depends = default, mcl_core, screwdriver, pipeworks, moreores, digilines, mesecons_mvps, techage
-min_minetest_version = 5.0
+min_minetest_version = 5.4


### PR DESCRIPTION
Less code, and `ItemStack:get_short_description()` will only return the first line of the description if `short_description` isn't defined, it also returns "Unknown Item" instead of an empty string for unknown items.